### PR TITLE
16KB page sizes support

### DIFF
--- a/android/convexmobile/build.gradle
+++ b/android/convexmobile/build.gradle
@@ -54,6 +54,12 @@ cargo {
     libname = "convexmobile"
     targets = ["arm64", "arm"]
     profile = "release"
+
+    exec { execSpecArg, _ ->
+        def pageSizeFlags = "-C link-args=-Wl,-z,max-page-size=16384"
+        def existingRustFlags = System.getenv("RUSTFLAGS") ?: ""
+        execSpecArg.environment("RUSTFLAGS", "${existingRustFlags} ${pageSizeFlags}".trim())
+    }
 }
 
 tasks.whenTaskAdded { task ->
@@ -75,7 +81,9 @@ tasks.register("generateUniFFIBinary", Exec) {
 android.libraryVariants.all { variant ->
     def t = tasks.register("generate${variant.name.capitalize()}UniFFIBindings", Exec) {
         workingDir "${project.projectDir}/../../rust"
-        commandLine './target/debug/uniffi-bindgen', 'generate', '--library', "${project.layout.buildDirectory.asFile.get().path}/rustJniLibs/android/arm64-v8a/libconvexmobile.so", '--language', 'kotlin', '--out-dir', "${project.layout.buildDirectory.asFile.get().path}/generated/source/uniffi/${variant.name}/java"
+        // Should work in linux/mac, tested in windows. Change if unnecessary
+        commandLine 'cargo', 'run', '--bin', 'uniffi-bindgen', '--', 'generate', '--library', "${project.layout.buildDirectory.asFile.get().path}/rustJniLibs/android/arm64-v8a/libconvexmobile.so", '--language', 'kotlin', '--out-dir', "${project.layout.buildDirectory.asFile.get().path}/generated/source/uniffi/${variant.name}/java"
+        //commandLine './target/debug/uniffi-bindgen', 'generate', '--library', "${project.layout.buildDirectory.asFile.get().path}/rustJniLibs/android/arm64-v8a/libconvexmobile.so", '--language', 'kotlin', '--out-dir', "${project.layout.buildDirectory.asFile.get().path}/generated/source/uniffi/${variant.name}/java"
         dependsOn 'generateUniFFIBinary'
     }
     def sourceSet = variant.sourceSets.find { it.name == variant.name }


### PR DESCRIPTION
<!-- Describe your PR here. -->
## Description
This PR configures the Android build to produce a Rust library compatible with 16KB memory page size

Fixes #6 

## How Has This Been Tested?
Confirmed the locally built library works by using it in the demo app.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
