### PR TITLE
Replace `aws-lc-rs` with `ring`

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,8 +17,11 @@ futures = { version = "0.3" }
 parking_lot = { version = "0.12.3" }
 async-once-cell = { version = "0.5.3" }
 serde_json = { version = "1.0.120" }
-rustls = { version = "0.23", features = ["aws-lc-rs"] }
-aws-lc-rs = { version = "1.14", features = ["bindgen"] }
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+    "tls12",
+] }
 
 [dev-dependencies]
 maplit = { version = "1" }


### PR DESCRIPTION
Building and compiling `aws-lc-rs` increases the dependencies needed to build this library.
The `bindgen` feature increases this complexity even more. 

`ring` has been much easier to work with and I would highly recommend the change
