### PR TITLE
fix(android): preserve nulls in nested JSON argument serialization

### DIFF
--- a/android/convexmobile/src/main/java/dev/convex/android/jsonhelpers.kt
+++ b/android/convexmobile/src/main/java/dev/convex/android/jsonhelpers.kt
@@ -19,8 +19,9 @@ internal fun Map<*, *>.toJsonElement(): JsonElement {
     val map: MutableMap<String, JsonElement> = mutableMapOf()
     this.forEach {
         val key = it.key as? String ?: return@forEach
-        val value = it.value ?: return@forEach
+        val value = it.value
         when (value) {
+            null -> map[key] = JsonNull
             is Map<*, *> -> map[key] = (value).toJsonElement()
             is List<*> -> map[key] = value.toJsonElement()
             else -> map[key] = value.toJsonElement()
@@ -33,8 +34,9 @@ internal fun Map<*, *>.toJsonElement(): JsonElement {
 internal fun List<*>.toJsonElement(): JsonElement {
     val list: MutableList<JsonElement> = mutableListOf()
     this.forEach {
-        val value = it ?: return@forEach
+        val value = it
         when (value) {
+            null -> list.add(JsonNull)
             is Map<*, *> -> list.add((value).toJsonElement())
             is List<*> -> list.add(value.toJsonElement())
             else -> list.add(value.toJsonElement())


### PR DESCRIPTION
## Summary
In the Android Kotlin client, nested null values inside Map/List args are dropped during arg serialization.

This breaks valid Convex calls that require explicit null, notably pagination first-page requests where `paginationOpts.cursor` should be null.

For paginated queries, first page commonly sends:
```kt
mapOf(
  "paginationOpts" to mapOf(
    "numItems" to 10,
    "cursor" to null
  )
)
```
When cursor is dropped instead of sent as null, backend validation can fail (missing required field / invalid args shape).

## Fix

Current logic in [jsonhelpers.kt](https://github.com/get-convex/convex-mobile/blob/089b0253a26b2a26b1cc967716995e7a28ae2aa3/android/convexmobile/src/main/java/dev/convex/android/jsonhelpers.kt#L21) skips nulls in nested structures:

`Map<*, *>.toJsonElement()` uses `it.value ?: return@forEach`
`List<*>.toJsonElement()` uses `it ?: return@forEach`

Preserve nested nulls as JsonNull instead of skipping:

`map entry null` -> `map[key] = JsonNull`
`list element null` -> `list.add(JsonNull)`

## Testing
Added/updated unit tests in `android/convexmobile/src/test/java/dev/convex/android/ConvexClientTest.kt` to cover nested null serialization for all arg entry points:

- `subscribe preserves nested nulls in maps and lists`
- `mutation preserves nested nulls in maps and lists`
- `action preserves nested nulls in maps and lists`

Each test validates that nested values are encoded with explicit JSON nulls, including:
- `paginationOpts.cursor = null`
- list null elements
- nested map fields set to null

Ran:
```bash
./gradlew :convexmobile:test --no-daemon
```
Result: `:convexmobile:test passed (BUILD SUCCESSFUL)`.

Used `RUST_ANDROID_GRADLE_PYTHON_COMMAND=/usr/bin/python3` to ensure compatibility with rust-android-gradle linker wrapper.

## Note on AI usage
I encountered this bug while coding a native android app with `gpt-codex-5.3-xhigh`. I have professional experience with Android development and Convex, but I relied on the agent to identify and fix this. From my conversations with it and my understanding, I believe the issue and our solution are valid.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
