### PR TITLE
Add tvOS build targets (device + simulator)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -160,47 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "aws-lc-fips-sys"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e78aabce84ab79501f4777e89cdcaec2a6ba9b051e6e6f26496598a84215c26"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "libloading",
- "regex",
-]
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
-dependencies = [
- "aws-lc-fips-sys",
- "aws-lc-sys",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "libloading",
-]
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,26 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
 ]
 
 [[package]]
@@ -316,18 +255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -335,17 +263,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
 
 [[package]]
 name = "clap"
@@ -386,15 +303,6 @@ name = "clap_lex"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
-
-[[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -443,7 +351,6 @@ dependencies = [
  "anyhow",
  "async-once-cell",
  "async-trait",
- "aws-lc-rs",
  "convex",
  "futures",
  "log",
@@ -563,18 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "env_filter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,12 +514,6 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1003,29 +892,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.3",
- "libc",
-]
 
 [[package]]
 name = "lazy_static"
@@ -1038,16 +908,6 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
-
-[[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if",
- "windows-targets 0.53.5",
-]
 
 [[package]]
 name = "litemap"
@@ -1221,16 +1081,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,15 +1191,9 @@ dependencies = [
  "getrandom 0.2.15",
  "libc",
  "spin",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustls"
@@ -1357,9 +1201,9 @@ version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1381,10 +1225,9 @@ version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -2028,12 +1871,6 @@ dependencies = [
  "uniffi_testing",
  "weedle2",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,13 +18,12 @@ futures = { version = "0.3" }
 parking_lot = { version = "0.12.3" }
 async-once-cell = { version = "0.5.3" }
 serde_json = { version = "1.0.120" }
-rustls = { version = "0.23", features = ["aws-lc-rs"] }
-aws-lc-rs = { version = "1.14", features = ["bindgen"], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
-default = ["aws-lc-rs"]
+default = []
 max_level_off = ["tracing/max_level_off"]
 max_level_error = ["tracing/max_level_error"]
 max_level_warn = ["tracing/max_level_warn"]

--- a/rust/build-ios.sh
+++ b/rust/build-ios.sh
@@ -27,6 +27,7 @@ done
 
 
 simulator_lib_dir="target/ios-simulator/release"
+tvos_simulator_lib_dir="target/tvos-simulator/release"
 
 generate_ffi() {
   echo "Generating framework module mapping and FFI bindings"
@@ -42,6 +43,12 @@ create_simulator_lib() {
   lipo -create target/aarch64-apple-ios-sim/release/lib$1.a -output $simulator_lib_dir/lib$1.a
 }
 
+create_tvos_simulator_lib() {
+  echo "Creating a library for aarch64 tvOS simulator"
+  mkdir -p $tvos_simulator_lib_dir
+  lipo -create target/aarch64-apple-tvos-sim/release/lib$1.a -output $tvos_simulator_lib_dir/lib$1.a
+}
+
 build_xcframework() {
   # Builds an XCFramework
   echo "Generating XCFramework"
@@ -50,6 +57,8 @@ build_xcframework() {
     -library target/aarch64-apple-ios/release/lib$1.a -headers target/uniffi-xcframework-staging \
     -library target/ios-simulator/release/lib$1.a -headers target/uniffi-xcframework-staging \
     -library target/aarch64-apple-darwin/release/lib$1.a -headers target/uniffi-xcframework-staging \
+    -library target/aarch64-apple-tvos/release/lib$1.a -headers target/uniffi-xcframework-staging \
+    -library target/tvos-simulator/release/lib$1.a -headers target/uniffi-xcframework-staging \
     -output target/ios/lib$1-rs.xcframework
   cp -R target/ios/lib$1-rs.xcframework ../ios
 
@@ -66,8 +75,11 @@ build_xcframework() {
 cargo build --lib --release --target aarch64-apple-ios-sim
 cargo build --lib --release --target aarch64-apple-ios
 cargo build --lib --release --target aarch64-apple-darwin
+cargo build --lib --release --target aarch64-apple-tvos
+cargo build --lib --release --target aarch64-apple-tvos-sim
 
 basename=convexmobile
 generate_ffi $basename
 create_simulator_lib $basename
+create_tvos_simulator_lib $basename
 build_xcframework $basename


### PR DESCRIPTION
## What

Adds `aarch64-apple-tvos` and `aarch64-apple-tvos-sim` to `build-ios.sh` and bundles their slices into the xcframework, so the Convex Swift client can be used on **tvOS**. This is additive — no API changes, existing iOS/macOS slices are untouched.

## Why

The Swift client is a great fit for always-on **dashboard, kiosk, and data-display apps on Apple TV** — read-heavy big-screen surfaces that benefit directly from Convex reactive subscriptions. Today the package builds for iOS + macOS only, so those apps can't adopt it without patching the core.

## How

The one non-trivial part is TLS. The crate forced rustls onto `aws-lc-rs`, which pulls in `aws-lc-sys` — a C/BoringSSL build (cmake + libclang) that does not cross-compile cleanly to Apple tvOS. This PR switches rustls to the pure-Rust **`ring`** provider:

```toml
rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
# aws-lc-rs dependency + default feature removed
```

`ring` 0.17.8 ships pregenerated assembly for the tvOS ABI — both `aarch64-apple-tvos` and `aarch64-apple-tvos-sim` report `target_os = "tvos"` — and builds with no C toolchain. rustls auto-selects `ring` as the process default when it's the only enabled provider, so no code changes are needed. `tokio`'s `full` features compile fine on tvOS (Darwin/BSD, `kqueue` via `mio`).

tvOS arm64 targets are **Tier 2** in Rust (prebuilt std), so real devices and Apple-silicon simulators need only `rustup target add aarch64-apple-tvos aarch64-apple-tvos-sim` + stable `cargo build` — no nightly / `-Z build-std`.

## Verified

Built the full xcframework (now with `tvos-arm64` + `tvos-arm64-simulator` slices) and consumed it from a SwiftUI tvOS app that runs end-to-end on the Apple TV simulator: live query subscriptions and a custom-`AuthProvider` bearer-token flow both work.

The companion Swift-package change (tvOS slices + `.tvOS` platform) is in get-convex/convex-swift.